### PR TITLE
fix: program panics when the user isn't a contributor of the repo

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -89,7 +89,7 @@ pub(crate) fn show_commit_stats(stats: &[Result<DiffStats, Box<dyn Error>>], use
             }
         });
 
-    println!("Commit statistics for user {}:", user_name);
+    println!("Commit statistics for user \"{}\":", user_name);
     println!("Files changed: {}", total_files_changed);
     println!("Insertions: {}", total_insertions);
     println!("Deletions: {}", total_deletions);

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -67,7 +67,15 @@ fn get_commit_stats_for_commit<'repo>(
 }
 
 /// Display commit statistics.
-pub(crate) fn show_commit_stats(stats: &[Result<DiffStats, Box<dyn Error>>]) {
+pub(crate) fn show_commit_stats(stats: &[Result<DiffStats, Box<dyn Error>>], user_name: &String) {
+    if stats.is_empty() {
+        println!(
+            "Warning: The user \"{}\" did not contribute to this repository.",
+            user_name
+        );
+        return;
+    }
+
     let (total_files_changed, total_insertions, total_deletions) =
         stats.iter().fold((0, 0, 0), |acc, commit_stats| {
             if let Ok(stats) = commit_stats {
@@ -81,7 +89,7 @@ pub(crate) fn show_commit_stats(stats: &[Result<DiffStats, Box<dyn Error>>]) {
             }
         });
 
-    println!("Commit statistics:");
+    println!("Commit statistics for user {}:", user_name);
     println!("Files changed: {}", total_files_changed);
     println!("Insertions: {}", total_insertions);
     println!("Deletions: {}", total_deletions);

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -183,7 +183,7 @@ pub(crate) fn get_user_name() -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::analyzer::{get_commit_stats, get_commits, get_repo, get_user_name};
+    use crate::analyzer::{get_commits, get_repo, get_user_name};
 
     #[test]
     fn show_commit_stats() {
@@ -198,9 +198,5 @@ mod tests {
         let user = get_user_name();
         println!("User: {}", user);
         assert!(!user.is_empty(), "Failed to get user name");
-
-        let stats = get_commit_stats(&repo, &commits.unwrap(), &user);
-        println!("Commit Stats: {:?}", stats);
-        assert!(!stats.is_empty(), "Failed to get commit stats");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,11 +77,6 @@ fn main() {
     let commits_vec = commits.unwrap();
     let stats = analyzer::get_commit_stats(&repo, &commits_vec, &user_name);
 
-    if stats.is_empty() {
-        eprintln!("Error: Failed to get commit stats.");
-        process::exit(1);
-    }
-
     analyzer::show_commit_stats(&stats);
     println!();
     analyzer::show_coding_habits(&commits_vec);

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn main() {
     let commits_vec = commits.unwrap();
     let stats = analyzer::get_commit_stats(&repo, &commits_vec, &user_name);
 
-    analyzer::show_commit_stats(&stats);
+    analyzer::show_commit_stats(&stats, &user_name);
     println!();
     analyzer::show_coding_habits(&commits_vec);
     println!();


### PR DESCRIPTION
Following error occurs when using this program:

```zsh
> git-commit-stats
Error: Failed to get commit stats.
```

The cause of it is that when the user hasn't contributed to the repo before, the vector returned by `analyzer::get_commit_stats` will be an empty vector, and the emptiness check will exit the program. 

In this pr, I deleted the emptiness check and the corresponding test. 