### PR TITLE
chore!: use Option type of clap and manually handling default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ Usage: git-commit-stats [OPTIONS]
 
 Options:
   -r, --repo-path <REPO_PATH>
-          Path to the Git repository (default = current directory) [default: ]
+          Path to the Git repository [default = current directory]
   -a, --after <AFTER>
-          Commit hash which commits should be analyzed (default = all) [default: ]
+          Commit hash which commits should be analyzed [default = all]
   -b, --before <BEFORE>
-          Commit hash before which commits should be analyzed (default = all) [default: ]
+          Commit hash before which commits should be analyzed [default = all]
   -u, --user <USER>
-          User name for commit analysis (default = git config user.name) [default: ]
+          User name for commit analysis [default = `git config user.name`]
   -t, --top-committers <TOP_COMMITTERS>
-          Amount of of top committers to show (default = 3) [default: 3]
+          Amount of of top committers to show [default = 3]
   -h, --help
           Print help
   -V, --version


### PR DESCRIPTION
When using the --help flag, the annoying default message in the end is ugly and meaningless: 

```zsh
> git-commit-stats --help
A tool to analyze git commits

Usage: git-commit-stats [OPTIONS]

Options:
  -r, --repo-path <REPO_PATH>
          ... (default = current directory) [default: ]
  -a, --after <AFTER>
          ... (default = all) [default: ]
  -b, --before <BEFORE>
          ... (default = all) [default: ]
  ...
  ...
  ...
```

To get rid of the annoying default messages, we can use the Option type when parsing the args using clap. And we can even gracefully handle the default values using customized logic. 

The program still works as expected after this pr and the new --help string will be like this:

```zsh
> git-commit-stats
A tool to analyze git commits

Usage: git-commit-stats [OPTIONS]

Options:
  -r, --repo-path <REPO_PATH>
          Path to the Git repository [default = current directory]
  -a, --after <AFTER>
          Commit hash which commits should be analyzed [default = all]
  -b, --before <BEFORE>
          Commit hash before which commits should be analyzed [default = all]
  -u, --user <USER>
          User name for commit analysis [default = `git config user.name`]
  -t, --top-committers <TOP_COMMITTERS>
          Amount of of top committers to show [default = 3]
  -h, --help
          Print help
  -V, --version
          Print version
```